### PR TITLE
Update qemu version to latest 3.x

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -127,7 +127,7 @@ Build QEMU with the RISC-V target:
          .. code-block:: bash
 
             cd qemu
-            git checkout v3.0.0
+            git checkout v3.1.1
             ./configure --target-list=riscv{{bits}}-softmmu
             make -j $(nproc)
             sudo make install


### PR DESCRIPTION
I had big issues getting networking to work with qemu.
In the end it worked after recompiling qemu with `git checkout -f v3.1.1`. 
I also tested the versions `v4.1.0` and `v4.0.0`, but those didn't compile with the `riscv64-softmmu` target.

Furthermore, I found that Fedora distributes pre-built disk images, which are way easier to use than compiling Linux yourself.
Should this tutorial be updated?
```bash
#QEMU still needs to be built from source though.

wget https://fedorapeople.org/groups/risc-v/disk-images/stage4-disk.img.xz
wget https://fedorapeople.org/groups/risc-v/disk-images/bbl
wget https://fedorapeople.org/groups/risc-v/disk-images/vmlinux
xz -d -k stage4-disk.img.xz 


qemu-system-riscv64 -nographic -machine virt \
    -m 2G -smp 4 \
    -kernel bbl \
    -object rng-random,filename=/dev/urandom,id=rng0 \
    -device virtio-rng-device,rng=rng0 \
    -append "console=ttyS0 ro root=/dev/vda" \
    -device virtio-blk-device,drive=hd0 \
    -drive file=stage4-disk.img,format=raw,id=hd0 \
    -device virtio-net-device,netdev=usernet \
    -netdev user,id=usernet,hostfwd=tcp::10000-:22
```