### PR TITLE
python3 is needed

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -17,7 +17,7 @@ Find instructions for various Linux distributions as well as macOS below:
 
          sudo apt install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev \
                           gawk build-essential bison flex texinfo gperf libtool patchutils bc \
-                          zlib1g-dev libexpat-dev git
+                          zlib1g-dev libexpat-dev git python3
 
    .. tab:: Fedora/CentOS/RHEL OS
 


### PR DESCRIPTION
as described https://github.com/riscv/risc-v-getting-started-guide/issues/14 