### PR TITLE
update zephyr SDK version

### DIFF
--- a/source/scripts/getting-zephyr.sh
+++ b/source/scripts/getting-zephyr.sh
@@ -17,10 +17,11 @@ pip3 install --user -r scripts/requirements.txt
 # set up env
 export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 export ZEPHYR_SDK_INSTALL_DIR="/opt/zephyr-sdk/"
+export ZEPHYR_SDK_VERSION="0.10.3"
 . ./zephyr-env.sh
 # /set up env
 
 # install Zephyr SDK
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.0/zephyr-sdk-0.10.0-setup.run
-sudo sh zephyr-sdk-0.10.0-setup.run -- -d $ZEPHYR_SDK_INSTALL_DIR
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run
+sudo sh zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run -- -d $ZEPHYR_SDK_INSTALL_DIR
 # /install Zephyr SDK


### PR DESCRIPTION
I was going through the documentation to run the risc-v demo and hit an issue that the zephyr-sdk was too old:
```
$ cmake -DBOARD=qemu_riscv32 $ZEPHYR_BASE/samples/hello_world
Zephyr version: 2.1.99
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.7.3", minimum required is "3.6")
-- Selected BOARD qemu_riscv32
CMake Error at /home/kkantor/zephyr/cmake/toolchain/zephyr/host-tools.cmake:49 (message):
  The SDK version you are using is too old, please update your SDK.

  You need at least SDK version 0.10.3.
  You have version 0.10.0 (/home/kkantor/zephyr-sdk).
  The new version of the SDK can be downloaded from:

  https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.3/zephyr-sdk-0.10.3-setup.run

Call Stack (most recent call first):
  /home/kkantor/zephyr/cmake/host-tools.cmake:3 (include)
  /home/kkantor/zephyr/cmake/app/boilerplate.cmake:443 (include)
  CMakeLists.txt:5 (include)

-- Configuring incomplete, errors occurred!
```

To test this I built the HTML documentation and pasted the modified instructions into my terminal:
```
$ export ZEPHYR_SDK_VERSION="0.10.3"
$ wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run
[...]
HTTP request sent, awaiting response... 200 OK
Length: 1143070277 (1.1G) [application/octet-stream]
Saving to: ‘zephyr-sdk-0.10.3-setup.run’

zephyr-sdk-0.10.3-setup.run    100%[==================================================>]   1.06G  10.6MB/s    in 1m 42s

2019-12-26 10:18:29 (10.7 MB/s) - ‘zephyr-sdk-0.10.3-setup.run’ saved [1143070277/1143070277]
$ sudo sh zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run -- -d $ZEPHYR_SDK_INSTALL_DIR
Verifying archive integrity... All good.
[...]
```

Rendered HTML also looks fine:
<img width="734" alt="zephyr_version_update" src="https://user-images.githubusercontent.com/3670292/71482848-57509f80-27ca-11ea-8f9f-c00a1a1e98b9.png">
