### PR TITLE
Replace Linux v5.4.0 tag with v5.4

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -112,7 +112,7 @@ First, checkout to a desired version:
          .. code-block:: bash
 
             cd linux
-            git checkout v5.4.0
+            git checkout v5.4
             make ARCH=riscv CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- defconfig
 
    {% endfor %}


### PR DESCRIPTION
```
Build Linux for the RISC-V target. First, checkout to a desired version:

cd linux
git checkout v5.4.0
make ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- defconfig
```

I couldn't find `v5.4.0` tag in [Linux repository](https://github.com/torvalds/linux) but I found `v5.4` tag. So I speculate `v5.4` would be right, not `v5.4.0`.