### PR TITLE
Fix missing tab for "Build Busybox:"

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -137,11 +137,23 @@ Then compile the kernel:
 
 Build Busybox:
 
-.. code-block:: bash
+.. jinja::
 
-    cd busybox
-    CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- make defconfig
-    CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- make -j $(nproc)
+   .. tabs::
+
+   {% for bits in [64,32] %}
+
+      .. group-tab:: {{bits}}-bit
+
+         .. code-block:: bash
+
+            cd busybox
+            CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- make defconfig
+            CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- make -j $(nproc)
+
+   {% endfor %}
+
+----------
 
 Running
 -------


### PR DESCRIPTION
"Build Busybox" section seems to miss tab. This PR fixes it.

![image](https://user-images.githubusercontent.com/7637832/91887528-bd39d480-ec3f-11ea-92d6-65cbf8efb1cf.png)
