### PR TITLE
Fix busybox path for running qemu

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -160,7 +160,7 @@ Go back to your main working directory and run:
 
             sudo qemu-system-riscv{{bits}} -nographic -machine virt \
                  -kernel linux/arch/riscv/boot/Image -append "root=/dev/vda ro console=ttyS0" \
-                 -drive file=busybox,format=raw,id=hd0 \
+                 -drive file=busybox/busybox,format=raw,id=hd0 \
                  -device virtio-blk-device,drive=hd0
 
    {% endfor %}


### PR DESCRIPTION
```
Running
Go back to your main working directory and run:

sudo qemu-system-riscv64 -nographic -machine virt \
     -kernel linux/arch/riscv/boot/Image -append "root=/dev/vda ro console=ttyS0" \
     -drive file=busybox,format=raw,id=hd0 \
     -device virtio-blk-device,drive=hd0
```

Assuming running the above command in main working directory so I think busybox file path should be `busybox/busybox`, not `busybox`.