### PR TITLE
Add ninja-build to linux-qemu guide prerequisites

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -23,20 +23,20 @@ Find instructions for various Linux distributions as well as macOS below:
 
          sudo apt install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev \
                           gawk build-essential bison flex texinfo gperf libtool patchutils bc \
-                          zlib1g-dev libexpat-dev git python3
+                          zlib1g-dev libexpat-dev git python3 ninja-build
 
    .. tab:: Fedora/CentOS/RHEL OS
 
       .. code-block:: bash
 
          sudo yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk bison flex \
-                          texinfo patchutils gcc gcc-c++ zlib-devel expat-devel git
+                          texinfo patchutils gcc gcc-c++ zlib-devel expat-devel git ninja-build
 
    .. tab:: macOS
 
       .. code-block:: bash
 
-         brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat
+         brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat ninja-build
 
 Getting the sources
 -------------------


### PR DESCRIPTION
QEMU added a build dependency on ninja-build in v0.5.2. It is required to
complete the linux-qemu guide.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://wiki.qemu.org/ChangeLog/5.2#Build_Dependencies