### PR TITLE
Checkout with a Git tag instead of a branch

### DIFF
--- a/source/linux-qemu.rst
+++ b/source/linux-qemu.rst
@@ -112,7 +112,7 @@ First, checkout to a desired version:
          .. code-block:: bash
 
             cd linux
-            git checkout v5.4.0
+            git checkout tags/v5.4 -b v5.4
             make ARCH=riscv CROSS_COMPILE=riscv{{bits}}-unknown-linux-gnu- defconfig
 
    {% endfor %}


### PR DESCRIPTION
https://github.com/torvalds/linux has the `v5.4` tag but doesn't have the `v5.4` branch.

So the command for `git checkout` should be:

```
$ git checkout tags/v5.4 -b v5.4
```

Thanks!